### PR TITLE
Fix Pet/Partner AI System

### DIFF
--- a/PlutoProject/SagaDB/MySQLActorDB.cs
+++ b/PlutoProject/SagaDB/MySQLActorDB.cs
@@ -213,6 +213,7 @@ namespace SagaDB
             ap.MaxMP = ap.BaseData.mp_in;
             ap.SP = ap.BaseData.sp_in;
             ap.MaxSP = ap.BaseData.sp_in;
+            ap.ai_mode = 1;
             uint apid = 0;
             //tbc
             string sqlstr;

--- a/PlutoProject/SagaMap/Network/Client/MapClient.Skill.cs
+++ b/PlutoProject/SagaMap/Network/Client/MapClient.Skill.cs
@@ -444,6 +444,8 @@ namespace SagaMap.Network.Client
                 sActor.TInt["targetID"] = (int)dActor.ActorID;
                 //SendSystemMessage("锁定了【" + dActor.Name + "】作为目标");
                 //Character.AutoAttack = true;
+
+                this.Character.PartnerTartget = dActor; // Partner will follow the entity assigned to PartnerTarget.
             }
 
             if (needthread)

--- a/PlutoProject/SagaMap/Partner/AICommands/Attack.cs
+++ b/PlutoProject/SagaMap/Partner/AICommands/Attack.cs
@@ -44,6 +44,11 @@ namespace SagaMap.Partner.AICommands
                 ActorPartner partner = (ActorPartner)partnerai.Partner;
                 uint[] ids = new uint[partnerai.Hate.Keys.Count];
                 partnerai.Hate.Keys.CopyTo(ids, 0);
+                /*
+                 * This is redundant because the partner doesn't need to search the map, which could cause weird movements. 
+                 * The partner should only follow ActorPC or the target that ActorPC is attacking.
+          
+
                 for (uint i = 0; i < partnerai.Hate.Keys.Count; i++)//Find out the actorPC with the highest hate value
                 {
                     if (ids[i] == 0) continue;
@@ -73,6 +78,9 @@ namespace SagaMap.Partner.AICommands
                         active = true;
                     }
                 }
+                */
+
+                id = partner.Owner.ActorID;
 
                 if (partner.Owner.PartnerTartget != null && partner.ai_mode <= 1)
                 {
@@ -157,7 +165,7 @@ namespace SagaMap.Partner.AICommands
                     continue;
                 if (isSlavaOfPc && i.type == ActorType.PC)
                     continue;
-                if(isSlavaOfPc && i.type == ActorType.MOB)
+                if (isSlavaOfPc && i.type == ActorType.MOB)
                 {
                     ActorEventHandlers.MobEventHandler ie = (ActorEventHandlers.MobEventHandler)i.e;
                     if (ie.AI.Master == this.partnerai.Master)
@@ -206,7 +214,7 @@ namespace SagaMap.Partner.AICommands
                 }
                 if (!partnerai.Hate.ContainsKey(target.ActorID))
                     partnerai.Hate.Add(target.ActorID, 20);
-                SendAggroEffect();
+                //SendAggroEffect();   no need for the exclamation mark to appear above the partner's head
             }
         }
 
@@ -353,7 +361,7 @@ namespace SagaMap.Partner.AICommands
                         attacktask = null;
                         return;
                     }
-                }                 
+                }
                 else
                 {
                     if (partnerai.Hate.ContainsKey(dest.ActorID)) partnerai.Hate.Remove(dest.ActorID);
@@ -426,4 +434,3 @@ namespace SagaMap.Partner.AICommands
         }
     }
 }
-    


### PR DESCRIPTION
**Changes:**

- Pet/partner will now only attack the target being attacked by ActorPC, or stay idle. Previously, they would randomly attack nearby NPCs.

- The mob AI has been commented out from pet/partner. They used to constantly search the map and move around, but now they will only follow ActorPC or the target ActorPC is attacking.

- Fixed a bug where pet/partner would appear idle when first summoned. Now, by default, their ai_mode are set to 1 (following mode) when first summoned.

https://github.com/karorogunso/SagaECO/assets/97398755/3decfbdd-321d-4c58-bcb4-2653a7e8e38f

@karorogunso @moldcode 